### PR TITLE
사용자 관련 API 구현

### DIFF
--- a/src/apis/store/goods.py
+++ b/src/apis/store/goods.py
@@ -17,7 +17,7 @@ async def get_goods_list_handler(
         [
             GetGoodsResponse(
                 id=goods.id,
-                brand=goods.seller.corporate_name,
+                brand_name=goods.seller.brand_name,
                 product_name=goods.product_name,
                 price=goods.price,
                 discounted_price=goods.discounted_price,
@@ -39,7 +39,7 @@ async def get_goods_by_id_handler(
     return GetGoodsDetailResponse(
         id=goods.id,
         category=goods.category.name,
-        brand=goods.seller.corporate_name,
+        brand_name=goods.seller.brand_name,
         product_name=goods.product_name,
         price=goods.price,
         discounted_price=goods.discounted_price,
@@ -49,5 +49,5 @@ async def get_goods_by_id_handler(
         how_to_use=goods.how_to_use,
         ingredient=goods.ingredient,
         caution=goods.caution,
-        contact=goods.seller.contact_information,
+        contact_number=goods.seller.contact_number,
     )

--- a/src/apis/user/__init__.py
+++ b/src/apis/user/__init__.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, status
+
+from src.apis.user import user
+
+user_router = APIRouter(tags=["user"])
+
+user_router.add_api_route(
+    methods=["POST"],
+    path="/register",
+    endpoint=user.register_user_handler,
+    response_model=user.GetRegisterInfoResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+
+user_router.add_api_route(
+    methods=["POST"],
+    path="/login",
+    endpoint=user.login_user_handler,
+    status_code=status.HTTP_200_OK,
+)
+
+user_router.add_api_route(
+    methods=["POST"],
+    path="/logout",
+    endpoint=user.logout_user_handler,
+    status_code=status.HTTP_200_OK,
+)
+
+user_router.add_api_route(
+    methods=["GET"],
+    path="/me",
+    endpoint=user.get_user_info_handler,
+    response_model=user.GetSellerInfoResponse | user.GetBuyerInfoResponse,
+    status_code=status.HTTP_200_OK,
+)

--- a/src/apis/user/user.py
+++ b/src/apis/user/user.py
@@ -1,0 +1,143 @@
+from fastapi import Cookie, Depends, HTTPException
+from fastapi.responses import JSONResponse
+
+from src.models.repository import UserRepository
+from src.models.user import Buyer, Seller, User, UserType
+from src.schema.request import LoginUserRequest, RegisterUserRequest
+from src.schema.response import (
+    GetBuyerInfoResponse,
+    GetRegisterInfoResponse,
+    GetSellerInfoResponse,
+)
+from src.service.session import SessionService
+from src.service.user import UserService
+
+
+async def register_user_handler(
+    request: RegisterUserRequest,
+    user_service: UserService = Depends(),
+    user_repo: UserRepository = Depends(),
+):
+    email = request.email
+    existing_user = await user_repo.get_user_by_email(email=email)
+    if existing_user:
+        raise HTTPException(status_code=400, detail="Email already registered.")
+
+    user_type = request.user_type
+    if user_type == UserType.SELLER:
+        is_valid_seller_data = await user_repo.validate_seller_unique_data(
+            request.registration_number, request.brand_name
+        )
+        if not is_valid_seller_data:
+            raise HTTPException(
+                status_code=400, detail="Seller data validation failed."
+            )
+
+    hashed_password = user_service.hash_password(request.password)
+
+    user: User = User(email=email, password=hashed_password, user_type=user_type)
+    created_user: User = await user_repo.save_entity(instance=user)
+
+    if user_type == UserType.SELLER:
+        seller: Seller = Seller(
+            user_id=created_user.id,
+            registration_number=request.registration_number,
+            brand_name=request.brand_name,
+            contact_number=request.contact_number,
+        )
+        created_seller = await user_repo.save_entity(instance=seller)
+
+        return GetRegisterInfoResponse(
+            user_type=created_seller.user.user_type,
+            email=created_seller.user.email,
+            name=created_seller.brand_name,
+        )
+
+    elif user_type == UserType.BUYER:
+        buyer: Buyer = Buyer(
+            user_id=created_user.id,
+            name=request.name,
+            phone_number=request.phone_number,
+            address=request.address,
+        )
+        created_buyer = await user_repo.save_entity(instance=buyer)
+
+        return GetRegisterInfoResponse(
+            user_type=created_buyer.user.user_type,
+            email=created_buyer.user.email,
+            name=created_buyer.name,
+        )
+
+
+async def login_user_handler(
+    request: LoginUserRequest,
+    user_service: UserService = Depends(),
+    session_service: SessionService = Depends(),
+    user_repo: UserRepository = Depends(),
+) -> JSONResponse:
+    user: User = await user_repo.get_user_by_email(email=request.email)
+    if not user:
+        raise HTTPException(status_code=404, detail="User Not Found.")
+
+    is_verified: bool = user_service.verify_password(
+        plain_password=request.password, hashed_password=user.password
+    )
+    if not is_verified:
+        raise HTTPException(status_code=401, detail="Not Authorized")
+
+    session_data = {"user_id": user.id, "user_type": user.user_type}
+    session_id = await session_service.create_session(session_data=session_data)
+
+    response = JSONResponse(content={"message": "Login successful"})
+    response.set_cookie(key="session_id", value=session_id, httponly=True)
+    return response
+
+
+async def logout_user_handler(
+    session_id: str = Cookie(None), session_service: SessionService = Depends()
+) -> JSONResponse:
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await session_service.get_session(session_id)
+    if not session_data:
+        raise HTTPException(status_code=404, detail="Session Not Found")
+
+    await session_service.delete_session(session_id)
+
+    response = JSONResponse(content={"message": "Logout successful"})
+    response.delete_cookie(key="session_id")
+    return response
+
+
+async def get_user_info_handler(
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+    user_repo: UserRepository = Depends(),
+) -> GetSellerInfoResponse | GetBuyerInfoResponse:
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await session_service.get_session(session_id)
+    if not session_data:
+        raise HTTPException(status_code=404, detail="Session Not Found")
+
+    user_id = session_data["user_id"]
+    user: User = await user_repo.get_user_by_id(user_id=user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User Not Found")
+
+    if user.user_type == UserType.SELLER:
+        return GetSellerInfoResponse(
+            email=user.email,
+            registration_number=user.seller.registration_number,
+            brand_name=user.seller.brand_name,
+            contact_number=user.seller.contact_number,
+        )
+
+    return GetBuyerInfoResponse(
+        email=user.email,
+        name=user.buyer.name,
+        phone_number=user.buyer.phone_number,
+        address=user.buyer.address,
+    )

--- a/src/apis/user/user.py
+++ b/src/apis/user/user.py
@@ -89,7 +89,7 @@ async def login_user_handler(
     session_id = await session_service.create_session(session_data=session_data)
 
     response = JSONResponse(content={"message": "Login successful"})
-    response.set_cookie(key="session_id", value=session_id, httponly=True)
+    response.set_cookie(key="session_id", value=session_id, httponly=True, secure=True)
     return response
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,13 @@ class WebConfig(BaseSettings):
     port: int = Field(default=os.getenv("WEB_PORT"), alias="WEB_PORT")
 
 
+class RedisConfig(BaseSettings):
+    host: str = Field(default=os.getenv("REDIS_HOST"), alias="REDIS_HOST")
+    port: str = Field(default=os.getenv("REDIS_PORT"), alias="REDIS_PORT")
+    db: str = Field(default=os.getenv("REDIS_DB"), alias="REDIS_DB")
+
+
 db = DatabaseConfig()
 cors = CORSConfig()
 web = WebConfig()
+redis = RedisConfig()

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from src import config
 from src.apis.common import common_router
 from src.apis.posts import post_router
 from src.apis.store import store_router
+from src.apis.user import user_router
 from src.database import close_db, create_db_and_tables
 
 
@@ -22,6 +23,7 @@ app = FastAPI(lifespan=lifespan)
 app.include_router(common_router)
 app.include_router(post_router)
 app.include_router(store_router)
+app.include_router(user_router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=config.cors.origins.split(","),

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -1,12 +1,15 @@
-from typing import List
+from typing import List, TypeVar
 
 from fastapi import Depends
 from sqlalchemy.orm import joinedload
-from sqlmodel import select
+from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.apis.dependencies import get_session
 from src.models.product import Product
+from src.models.user import Seller, User
+
+T = TypeVar("T", bound=SQLModel)
 
 
 class ProductRepository:
@@ -44,3 +47,33 @@ class ProductRepository:
     async def delete_product(self, product: Product) -> None:
         product.use_status = False
         await self.session.commit()
+
+
+class UserRepository:
+    def __init__(self, session: AsyncSession = Depends(get_session)):
+        self.session = session
+
+    async def get_user_by_email(self, email: str) -> User:
+        result = await self.session.exec(select(User).where(User.email == email))
+        return result.one_or_none()
+
+    async def get_user_by_id(self, user_id: int) -> User:
+        result = await self.session.exec(select(User).where(User.id == user_id))
+        return result.one_or_none()
+
+    async def save_entity(self, instance: T) -> T:
+        self.session.add(instance=instance)
+        await self.session.commit()
+        await self.session.refresh(instance=instance)
+        return instance
+
+    async def validate_seller_unique_data(
+        self, registration_number: str, brand_name: str
+    ) -> bool:
+        result = await self.session.exec(
+            select(Seller).where(
+                (Seller.registration_number == registration_number)
+                | (Seller.brand_name == brand_name)
+            )
+        )
+        return result.first() is None

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -20,8 +20,12 @@ class User(SQLModel, table=True):
     password: str = Field(sa_column=Column(String(255), nullable=False))
     user_type: UserType = Field(sa_column=Column(SqlEnum(UserType), nullable=False))
 
-    seller: Optional["Seller"] = Relationship(back_populates="user")
-    buyer: Optional["Buyer"] = Relationship(back_populates="user")
+    seller: Optional["Seller"] = Relationship(
+        back_populates="user", sa_relationship_kwargs={"lazy": "joined"}
+    )
+    buyer: Optional["Buyer"] = Relationship(
+        back_populates="user", sa_relationship_kwargs={"lazy": "joined"}
+    )
 
 
 class Seller(SQLModel, table=True):
@@ -35,7 +39,9 @@ class Seller(SQLModel, table=True):
     brand_name: str = Field(sa_column=Column(String(50), nullable=False, unique=True))
     contact_number: Optional[str] = Field(sa_column=Column(String(20), nullable=False))
 
-    user: User = Relationship(back_populates="seller")
+    user: User = Relationship(
+        back_populates="seller", sa_relationship_kwargs={"lazy": "joined"}
+    )
     products: List["Product"] = Relationship(back_populates="seller")
 
 
@@ -48,4 +54,6 @@ class Buyer(SQLModel, table=True):
     phone_number: str = Field(sa_column=Column(String(20), nullable=False))
     address: str = Field(sa_column=Column(String(200), nullable=False))
 
-    user: User = Relationship(back_populates="buyer")
+    user: User = Relationship(
+        back_populates="buyer", sa_relationship_kwargs={"lazy": "joined"}
+    )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,34 +1,51 @@
+from enum import Enum
 from typing import List, Optional
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column
+from sqlalchemy import Enum as SqlEnum
+from sqlalchemy import String
 from sqlmodel import Field, Relationship, SQLModel
+
+
+class UserType(str, Enum):
+    SELLER = "SELLER"
+    BUYER = "BUYER"
+
+
+class User(SQLModel, table=True):
+    __tablename__ = "users"
+
+    id: Optional[int] = Field(default=None, primary_key=True, index=True)
+    email: str = Field(sa_column=Column(String(255), nullable=False, unique=True))
+    password: str = Field(sa_column=Column(String(255), nullable=False))
+    user_type: UserType = Field(sa_column=Column(SqlEnum(UserType), nullable=False))
+
+    seller: Optional["Seller"] = Relationship(back_populates="user")
+    buyer: Optional["Buyer"] = Relationship(back_populates="user")
 
 
 class Seller(SQLModel, table=True):
     __tablename__ = "sellers"
 
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
-    email: str = Field(sa_column=Column(String(255), nullable=False, unique=True))
-    password: str = Field(sa_column=Column(String(255), nullable=False))
+    user_id: int = Field(foreign_key="users.id", nullable=False)
     registration_number: str = Field(
         sa_column=Column(String(20), nullable=False, unique=True)
     )
-    corporate_name: str = Field(
-        sa_column=Column(String(50), nullable=False, unique=True)
-    )
-    contact_information: Optional[str] = Field(
-        sa_column=Column(String(20), nullable=False)
-    )
+    brand_name: str = Field(sa_column=Column(String(50), nullable=False, unique=True))
+    contact_number: Optional[str] = Field(sa_column=Column(String(20), nullable=False))
 
+    user: User = Relationship(back_populates="seller")
     products: List["Product"] = Relationship(back_populates="seller")
 
 
-class Customer(SQLModel, table=True):
-    __tablename__ = "customers"
+class Buyer(SQLModel, table=True):
+    __tablename__ = "buyers"
 
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
-    email: str = Field(sa_column=Column(String(255), nullable=False, unique=True))
-    password: str = Field(sa_column=Column(String(255), nullable=False))
+    user_id: int = Field(foreign_key="users.id", nullable=False)
     name: str = Field(sa_column=Column(String(50), nullable=False))
     phone_number: str = Field(sa_column=Column(String(20), nullable=False))
     address: str = Field(sa_column=Column(String(200), nullable=False))
+
+    user: User = Relationship(back_populates="buyer")

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from sqlalchemy import Column, String
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -7,10 +8,27 @@ class Seller(SQLModel, table=True):
     __tablename__ = "sellers"
 
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
-    email: str = Field(nullable=False, max_length=100, unique=True)
-    password: str = Field(nullable=False, max_length=256)
-    registration_number: str = Field(nullable=False, max_length=20, unique=True)
-    corporate_name: str = Field(nullable=False, max_length=20, unique=True)
-    contact_information: Optional[str] = Field(default=None, max_length=50)
+    email: str = Field(sa_column=Column(String(255), nullable=False, unique=True))
+    password: str = Field(sa_column=Column(String(255), nullable=False))
+    registration_number: str = Field(
+        sa_column=Column(String(20), nullable=False, unique=True)
+    )
+    corporate_name: str = Field(
+        sa_column=Column(String(50), nullable=False, unique=True)
+    )
+    contact_information: Optional[str] = Field(
+        sa_column=Column(String(20), nullable=False)
+    )
 
     products: List["Product"] = Relationship(back_populates="seller")
+
+
+class Customer(SQLModel, table=True):
+    __tablename__ = "customers"
+
+    id: Optional[int] = Field(default=None, primary_key=True, index=True)
+    email: str = Field(sa_column=Column(String(255), nullable=False, unique=True))
+    password: str = Field(sa_column=Column(String(255), nullable=False))
+    name: str = Field(sa_column=Column(String(50), nullable=False))
+    phone_number: str = Field(sa_column=Column(String(20), nullable=False))
+    address: str = Field(sa_column=Column(String(200), nullable=False))

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -1,0 +1,15 @@
+from redis.asyncio import Redis
+
+from src.config import redis as redis_config
+
+redis_client = Redis(
+    host=redis_config.host,
+    port=redis_config.port,
+    db=redis_config.db,
+    encoding="UTF-8",
+    decode_responses=True,
+)
+
+
+def get_redis_client() -> Redis:
+    return redis_client

--- a/src/schema/request.py
+++ b/src/schema/request.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr, Field, constr
+
+from src.models.user import UserType
 
 
 class CreateProductRequest(BaseModel):
@@ -30,3 +32,26 @@ class UpdateProductRequest(BaseModel):
     ingredient: Optional[str] = None
     caution: Optional[str] = None
     inventory_quantity: Optional[int] = None
+
+
+class RegisterUserRequest(BaseModel):
+    email: EmailStr
+    password: constr(min_length=8, max_length=20)
+    user_type: UserType
+
+    # 판매자 정보
+    registration_number: Optional[str] = Field(None, pattern=r"^\d{3}-\d{2}-\d{5}$")
+    brand_name: Optional[str] = None
+    contact_number: Optional[str] = Field(
+        None, pattern=r"^(\d{2,3}-\d{3,4}-\d{4}|\d{4}-\d{4})$"
+    )
+
+    # 구매자 정보
+    name: Optional[str] = None
+    phone_number: Optional[str] = Field(None, pattern=r"^\d{3}-\d{3,4}-\d{4}$")
+    address: Optional[str] = None
+
+
+class LoginUserRequest(BaseModel):
+    email: EmailStr
+    password: str

--- a/src/schema/response.py
+++ b/src/schema/response.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 class GetGoodsResponse(BaseModel):
     id: int
-    brand: str
+    brand_name: str
     product_name: str
     price: int
     discounted_price: int
@@ -14,7 +14,7 @@ class GetGoodsResponse(BaseModel):
 class GetGoodsDetailResponse(BaseModel):
     id: int
     category: str
-    brand: str
+    brand_name: str
     product_name: str
     price: int
     discounted_price: int
@@ -24,7 +24,7 @@ class GetGoodsDetailResponse(BaseModel):
     how_to_use: Optional[str] = None
     ingredient: Optional[str] = None
     caution: Optional[str] = None
-    contact: str
+    contact_number: str
 
 
 class GetProductResponse(BaseModel):

--- a/src/schema/response.py
+++ b/src/schema/response.py
@@ -48,3 +48,23 @@ class GetProductDetailResponse(BaseModel):
     caution: Optional[str] = None
     inventory_quantity: int
     use_status: bool
+
+
+class GetRegisterInfoResponse(BaseModel):
+    user_type: str
+    email: str
+    name: str
+
+
+class GetSellerInfoResponse(BaseModel):
+    email: str
+    registration_number: str
+    brand_name: str
+    contact_number: Optional[str] = None
+
+
+class GetBuyerInfoResponse(BaseModel):
+    email: str
+    name: str
+    phone_number: str
+    address: str

--- a/src/service/session.py
+++ b/src/service/session.py
@@ -1,0 +1,31 @@
+import json
+import secrets
+from datetime import timedelta
+from typing import Optional
+
+from fastapi import Depends
+from redis.asyncio import Redis
+
+from src.redis_client import get_redis_client
+
+
+class SessionService:
+    def __init__(self, redis_client: Redis = Depends(get_redis_client)):
+        self.redis_client = redis_client
+
+    async def create_session(self, session_data: dict) -> str:
+        session_id = secrets.token_hex(16)
+        session_expires = timedelta(hours=1)
+        await self.redis_client.setex(
+            session_id, session_expires, value=json.dumps(session_data)
+        )
+        return session_id
+
+    async def get_session(self, session_id: str) -> Optional[dict]:
+        session_data = await self.redis_client.get(session_id)
+        if session_data:
+            return json.loads(session_data)
+        return None
+
+    async def delete_session(self, session_id: str):
+        await self.redis_client.delete(session_id)

--- a/src/service/user.py
+++ b/src/service/user.py
@@ -1,0 +1,16 @@
+import bcrypt
+
+
+class UserService:
+    encoding: str = "UTF-8"
+
+    def hash_password(self, plain_password: str) -> str:
+        hashed_password: bytes = bcrypt.hashpw(
+            plain_password.encode(self.encoding), salt=bcrypt.gensalt()
+        )
+        return hashed_password.decode(self.encoding)
+
+    def verify_password(self, plain_password: str, hashed_password: str) -> bool:
+        return bcrypt.checkpw(
+            plain_password.encode(self.encoding), hashed_password.encode(self.encoding)
+        )

--- a/tests/apis/conftest.py
+++ b/tests/apis/conftest.py
@@ -1,9 +1,11 @@
 import pytest_asyncio
 from httpx import AsyncClient
+from redis.asyncio import Redis
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.database import close_db, create_db_and_tables, engine
 from src.main import app
+from src.redis_client import get_redis_client
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -18,3 +20,10 @@ async def client() -> AsyncClient:
 async def session() -> AsyncSession:
     async with AsyncSession(engine) as session:
         yield session
+
+
+@pytest_asyncio.fixture(scope="function")
+async def redis_client() -> Redis:
+    client = get_redis_client()
+    yield client
+    await client.close()

--- a/tests/apis/user/test_user.py
+++ b/tests/apis/user/test_user.py
@@ -1,0 +1,319 @@
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+
+from src.models.repository import UserRepository
+from src.models.user import Buyer, Seller, User, UserType
+from src.service.session import SessionService
+from src.service.user import UserService
+
+
+# 'POST /register' API가 판매자(Seller)를 성공적으로 등록한다.
+@pytest.mark.asyncio
+async def test_register_seller_successfully(client: AsyncClient, mocker):
+    mock_seller_data = {
+        "email": "test@example.com",
+        "password": "hashed_password",
+        "user_type": UserType.SELLER,
+        "registration_number": "000-00-00000",
+        "brand_name": "테스트",
+        "contact_number": "0000-0000",
+    }
+    created_user = User(
+        id=1,
+        email=mock_seller_data["email"],
+        password=mock_seller_data["password"],
+        user_type=mock_seller_data["user_type"],
+    )
+    created_seller = Seller(
+        id=1,
+        user_id=created_user.id,
+        registration_number=mock_seller_data["registration_number"],
+        brand_name=mock_seller_data["brand_name"],
+        contact_number=mock_seller_data["contact_number"],
+        user=created_user,
+    )
+
+    mocker.patch.object(UserRepository, "get_user_by_email", return_value=None)
+    mocker.patch.object(
+        UserRepository, "validate_seller_unique_data", return_value=True
+    )
+    mocker.patch.object(
+        UserService, "hash_password", return_value=mock_seller_data["password"]
+    )
+    mocker.patch.object(
+        UserRepository, "save_entity", side_effect=[created_user, created_seller]
+    )
+
+    response = await client.post("/register", json=mock_seller_data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    data = response.json()
+    assert data == {
+        "user_type": created_user.user_type,
+        "email": created_user.email,
+        "name": created_seller.brand_name,
+    }
+
+
+# 'POST /register' API가 중복된 사업자등록번호를 사용하는 경우 400을 응답한다.
+@pytest.mark.asyncio
+async def test_register_seller_with_duplicate_registration_number(
+    client: AsyncClient, mocker
+):
+    mock_seller_data = {
+        "email": "test@example.com",
+        "password": "hashed_password",
+        "user_type": UserType.SELLER,
+        "registration_number": "000-00-00000",  # 이미 등록된 사업자등록번호
+        "brand_name": "테스트",
+        "contact_number": "0000-0000",
+    }
+
+    # 중복된 사업자등록번호를 가진 판매자가 이미 존재한다고 가정
+    mocker.patch.object(
+        UserRepository, "validate_seller_unique_data", return_value=False
+    )
+
+    response = await client.post("/register", json=mock_seller_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Seller data validation failed."}
+
+
+# 'POST /register' API가 구매자(Buyer)를 성공적으로 등록한다.
+@pytest.mark.asyncio
+async def test_register_buyer_successfully(client: AsyncClient, mocker):
+    mock_buyer_data = {
+        "email": "test@example.com",
+        "password": "hashed_password",
+        "user_type": UserType.BUYER,
+        "name": "사용자",
+        "phone_number": "010-0000-0000",
+        "address": "xx도 oo시 xx동",
+    }
+    created_user = User(
+        id=1,
+        email=mock_buyer_data["email"],
+        password=mock_buyer_data["password"],
+        user_type=mock_buyer_data["user_type"],
+    )
+    created_buyer = Buyer(
+        id=1,
+        user_id=created_user.id,
+        name=mock_buyer_data["name"],
+        phone_number=mock_buyer_data["phone_number"],
+        address=mock_buyer_data["address"],
+        user=created_user,
+    )
+
+    mocker.patch.object(UserRepository, "get_user_by_email", return_value=None)
+    mocker.patch.object(
+        UserRepository, "validate_seller_unique_data", return_value=True
+    )
+    mocker.patch.object(
+        UserService, "hash_password", return_value=mock_buyer_data["password"]
+    )
+    mocker.patch.object(
+        UserRepository, "save_entity", side_effect=[created_user, created_buyer]
+    )
+
+    response = await client.post("/register", json=mock_buyer_data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    data = response.json()
+    assert data == {
+        "user_type": created_user.user_type,
+        "email": created_user.email,
+        "name": created_buyer.name,
+    }
+
+
+# 'POST /register' API가 이미 등록된 이메일을 사용하는 경우 400을 반환한다.
+@pytest.mark.asyncio
+async def test_register_user_with_existing_email(client: AsyncClient, mocker):
+    mock_user_data = {
+        "email": "test@example.com",  # 이미 등록된 이메일
+        "password": "hashed_password",
+        "user_type": UserType.BUYER,
+        "name": "사용자",
+        "phone_number": "010-0000-0000",
+        "address": "xx도 oo시 xx동",
+    }
+    existing_user = User(id=1, email="test@example.com")
+
+    # 중복된 이메일을 가진 사용자가 이미 존재한다고 가정
+    mocker.patch.object(UserRepository, "get_user_by_email", return_value=existing_user)
+
+    response = await client.post("/register", json=mock_user_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# 'POST /login' API가 성공적으로 로그인한다.
+@pytest.mark.asyncio
+async def test_login_user_successfully(client: AsyncClient, mocker):
+    mock_login_data = {"email": "test@example.com", "password": "hashed_password"}
+    user: User = User(
+        id=1,
+        email=mock_login_data["email"],
+        password=mock_login_data["password"],
+        user_type=UserType.BUYER,
+    )
+    created_session_id = "mock_session_id"
+
+    mocker.patch.object(UserRepository, "get_user_by_email", return_value=user)
+    mocker.patch.object(UserService, "verify_password", return_value=True)
+    mocker.patch.object(
+        SessionService, "create_session", return_value=created_session_id
+    )
+
+    response = await client.post("/login", json=mock_login_data)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"message": "Login successful"}
+    assert response.cookies["session_id"] == created_session_id
+
+
+# 'POST /login' API가 잘못된 비밀번호를 입력하는 경우 401을 반환한다.
+@pytest.mark.asyncio
+async def test_login_user_invalid_password(client: AsyncClient, mocker):
+    mock_login_data = {
+        "email": "test@example.com",
+        "password": "wrong_password",  # 잘못된 비밀번호
+    }
+    user: User = User(
+        id=1,
+        email=mock_login_data["email"],
+        password="hashed_password",
+        user_type=UserType.BUYER,
+    )
+
+    mocker.patch.object(UserRepository, "get_user_by_email", return_value=user)
+    mocker.patch.object(UserService, "verify_password", return_value=False)
+
+    response = await client.post("/login", json=mock_login_data)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not Authorized"}
+
+
+# 'POST /logout' API가 성공적으로 로그아웃한다.
+@pytest.mark.asyncio
+async def test_logout_user_successfully(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mock_login_user_data = {"user_id": 1, "user_type": UserType.BUYER}
+
+    mocker.patch.object(
+        SessionService, "get_session", return_value=mock_login_user_data
+    )
+    mocker.patch.object(SessionService, "delete_session")
+
+    response = await client.post("/logout", cookies={"session_id": mock_session_id})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"message": "Logout successful"}
+
+
+# 'POST /logout' API가 유효하지 않은 세션 ID의 경우 404를 반환한다.
+@pytest.mark.asyncio
+async def test_logout_user_invalid_session_id(client: AsyncClient, mocker):
+    invalid_session_id = "invalid_session_id"
+
+    mocker.patch.object(SessionService, "get_session", return_value=None)
+
+    response = await client.post("/logout", cookies={"session_id": invalid_session_id})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "Session Not Found"}
+
+
+# 'GET /me' API가 판매자(Seller) 정보를 성공적으로 반환한다.
+@pytest.mark.asyncio
+async def test_get_seller_info_successfully(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1,
+        email="test@example.com",
+        password="hashed_password",
+        user_type=UserType.SELLER,
+    )
+    mock_seller_info = Seller(
+        id=1,
+        user_id=mock_user.id,
+        registration_number="000-00-00000",
+        brand_name="테스트 브랜드",
+        contact_number="0000-0000",
+        user=mock_user,
+    )
+
+    mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": mock_user.id, "user_type": mock_user.user_type},
+    )
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
+
+    response = await client.get("/me", cookies={"session_id": mock_session_id})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data == {
+        "email": mock_user.email,
+        "registration_number": mock_seller_info.registration_number,
+        "brand_name": mock_seller_info.brand_name,
+        "contact_number": mock_seller_info.contact_number,
+    }
+
+
+# 'GET /me' API가 구매자(Buyer) 정보를 성공적으로 반환한다.
+@pytest.mark.asyncio
+async def test_get_buyer_info_successfully(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1,
+        email="test@example.com",
+        password="hashed_password",
+        user_type=UserType.BUYER,
+    )
+    mock_buyer_info = Buyer(
+        id=1,
+        user_id=mock_user.id,
+        name="사용자",
+        phone_number="010-0000-0000",
+        address="xx도 oo시 xx동",
+        user=mock_user,
+    )
+
+    mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": mock_user.id, "user_type": mock_user.user_type},
+    )
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
+
+    response = await client.get("/me", cookies={"session_id": mock_session_id})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data == {
+        "email": mock_user.email,
+        "name": mock_buyer_info.name,
+        "phone_number": mock_buyer_info.phone_number,
+        "address": mock_buyer_info.address,
+    }
+
+
+# 'GET /me' API가 세션 ID가 유효하지 않은 경우 404를 반환한다.
+@pytest.mark.asyncio
+async def test_get_user_info_invalid_session_id(client: AsyncClient, mocker):
+    invalid_session_id = "invalid_session_id"
+
+    mocker.patch.object(SessionService, "get_session", return_value=None)
+
+    response = await client.get("/me", cookies={"session_id": invalid_session_id})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "Session Not Found"}


### PR DESCRIPTION
### 작업 내용
- [x] 사용자 유형별 모델 작성 - 사용자(User)를 상속받는 형태의 구매자(Buyer), 판매자(Seller) 모델 생성
- [x] 세션 ID 저장을 위한 Redis 연결 설정
- [x] 사용자 관련 API 구현 - 회원가입, 로그인, 로그아웃, 정보 조회
- [x] 구현 내용 관련 테스트 코드 작성 

### 설명
- 사용자는 모두 email과 password라는 공통 필드를 사용하기 때문에 이 필드를 포함한 사용자(User) 테이블을 상속 받아 구매자(Buyer), 판매자(Seller)가 생성되도록 하였습니다. (FK를 활용하여 관계가 형성되도록 함)
- `user_type`을 이용하여 사용자 유형(Buyer 또는 Seller)을 확인하고, 회원가입과 회원정보 조회 시 요청이나 응답이 유형에 따라 달라지도록 작성했습니다.
- Redis를 연결, 로그인 시 세션 ID를 생성하여 Redis에 사용자 관련 정보를 저장하고, 쿠키에 세션 ID를 저장했습니다.
- 회원가입 시 비밀번호는 해시된 비밀번호로 저장하고, 로그인 시 생성되는 세션 ID는 랜덤한 값으로 생성하여 암호화 될 수 있도록 했습니다.

### 테스트 코드
사용자 관련 API에 대해 단위 테스트 진행
- 판매자 등록 (`POST /register`) : 성공 - 201 Created 반환, 실패(중복된 사업자등록번호) - 400 Bad Request 반환
- 구매자 등록 (`POST /register`) : 성공 - 201 Created 반환, 실패(중복된 이메일) - 400 Bad Request 반환
- 로그인 (`POST /login`) : 성공 - 200 OK 및 세션 ID 반환, 실패(잘못된 비밀번호) - 401 Unauthorized 반환
- 로그아웃 (`POST /logout`) : 성공 - 200 OK 반환, 실패(유효하지 않은 세션 ID) - 404 Not Found 반환
- 사용자 정보 조회(`GET /me`) : 성공 - 200 OK 반환, 실패(유효하지 않은 세션 ID) - 404 Not Found 반환

### 기타 사항
- 사용자 정보 수정을 위한 추가 기능 필요
