### PR TITLE
상품 관련 API 중 판매자 확인 및 상품 소유 여부 검증 추가

### DIFF
--- a/src/schema/request.py
+++ b/src/schema/request.py
@@ -6,7 +6,7 @@ from src.models.user import UserType
 
 
 class CreateProductRequest(BaseModel):
-    seller_id: int
+    # seller_id: int
     product_name: str
     category_id: int
     price: int

--- a/src/service/auth.py
+++ b/src/service/auth.py
@@ -1,0 +1,31 @@
+from fastapi import HTTPException
+
+from src.models.user import UserType
+from src.service.session import SessionService
+
+
+async def get_session_data(session_id: str, session_service: SessionService) -> dict:
+    session_data = await session_service.get_session(session_id=session_id)
+    if not session_data:
+        raise HTTPException(status_code=404, detail="Session Not Found")
+
+    return session_data
+
+
+async def verify_seller(session_id: str, session_service: SessionService) -> int:
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    user_type = session_data["user_type"]
+    if user_type != UserType.SELLER:
+        raise HTTPException(status_code=403, detail="Not Authorized")
+
+    return session_data["user_id"]
+
+
+async def verify_user_can_access_product(
+    seller_id: int, product_seller_id: int
+) -> None:
+    if seller_id != product_seller_id:
+        raise HTTPException(status_code=403, detail="Access denied")

--- a/tests/apis/conftest.py
+++ b/tests/apis/conftest.py
@@ -1,9 +1,13 @@
+import asyncio
+
 import pytest_asyncio
 from httpx import AsyncClient
+from redis.asyncio import Redis
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.database import close_db, create_db_and_tables, engine
 from src.main import app
+from src.redis_client import get_redis_client
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -18,3 +22,17 @@ async def client() -> AsyncClient:
 async def session() -> AsyncSession:
     async with AsyncSession(engine) as session:
         yield session
+
+
+@pytest_asyncio.fixture(scope="function")
+async def redis_client() -> Redis:
+    client = get_redis_client()
+    yield client
+    await client.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()

--- a/tests/apis/store/test_goods.py
+++ b/tests/apis/store/test_goods.py
@@ -10,8 +10,8 @@ from src.models.user import Seller
 # 'GET /goods' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_goods_list_successfully(client: AsyncClient, mocker):
-    seller_1 = Seller(id=1, corporate_name="판매자1")
-    seller_2 = Seller(id=2, corporate_name="판매자2")
+    seller_1 = Seller(id=1, brand_name="판매자1")
+    seller_2 = Seller(id=2, brand_name="판매자2")
 
     product_1 = Product(
         id=1,
@@ -58,14 +58,14 @@ async def test_goods_list_successfully(client: AsyncClient, mocker):
     assert data == [
         {
             "id": product_3.id,
-            "brand": product_3.seller.corporate_name,
+            "brand_name": product_3.seller.brand_name,
             "product_name": product_3.product_name,
             "price": product_3.price,
             "discounted_price": product_3.discounted_price,
         },
         {
             "id": product_1.id,
-            "brand": product_1.seller.corporate_name,
+            "brand_name": product_1.seller.brand_name,
             "product_name": product_1.product_name,
             "price": product_1.price,
             "discounted_price": product_1.discounted_price,
@@ -76,7 +76,7 @@ async def test_goods_list_successfully(client: AsyncClient, mocker):
 # 'GET /goods/{goods_id}' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_get_goods_by_id_successfully(client: AsyncClient, mocker):
-    seller = Seller(id=1, corporate_name="판매자", contact_information="000-000-0000")
+    seller = Seller(id=1, brand_name="판매자", contact_number="000-000-0000")
     category = TertiaryCategory(id=1, name="카테고리")
 
     product = Product(
@@ -100,7 +100,7 @@ async def test_get_goods_by_id_successfully(client: AsyncClient, mocker):
     assert data == {
         "id": product.id,
         "category": product.category.name,
-        "brand": product.seller.corporate_name,
+        "brand_name": product.seller.brand_name,
         "product_name": product.product_name,
         "price": product.price,
         "discounted_price": product.discounted_price,
@@ -110,7 +110,7 @@ async def test_get_goods_by_id_successfully(client: AsyncClient, mocker):
         "how_to_use": product.how_to_use,
         "ingredient": product.ingredient,
         "caution": product.caution,
-        "contact": product.seller.contact_information,
+        "contact_number": product.seller.contact_number,
     }
 
 

--- a/tests/apis/store/test_product.py
+++ b/tests/apis/store/test_product.py
@@ -3,15 +3,28 @@ from fastapi import status
 from httpx import AsyncClient
 
 from src.models.product import Product, TertiaryCategory
-from src.models.repository import ProductRepository
-from src.models.user import Seller
+from src.models.repository import ProductRepository, UserRepository
+from src.models.user import Seller, User, UserType
+from src.service.session import SessionService
 
 
 # 'POST /products/' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_create_product_successfully(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1, email="test@example.com", password="hashed_pw", user_type=UserType.SELLER
+    )
+    mock_seller = Seller(
+        id=1,
+        user_id=1,
+        registration_number="111-11-11111",
+        brand_name="TestBrand",
+        contact_number="000-000-0000",
+        user=mock_user,
+    )
     product_data = {
-        "seller_id": 1,
+        "seller_id": mock_seller.id,
         "product_name": "테스트 상품",
         "category_id": 1,
         "price": 10000,
@@ -19,10 +32,19 @@ async def test_create_product_successfully(client: AsyncClient, mocker):
     created_product = Product(id=1, **product_data)
 
     mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": 1, "user_type": UserType.SELLER},
+    )
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
+    mocker.patch.object(
         ProductRepository, "create_product", return_value=created_product
     )
 
-    response = await client.post("/products", json=product_data)
+    response = await client.post(
+        "/products", json=product_data, cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -37,7 +59,10 @@ async def test_create_product_successfully(client: AsyncClient, mocker):
 
 # 'POST /products/' API가 잘못된 데이터를 받으면 422를 응답한다.
 @pytest.mark.asyncio
-async def test_create_product_with_invalid_data(client: AsyncClient):
+async def test_create_product_with_invalid_data(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+
     # 잘못된 요청 데이터 (예: price가 없는 경우)
     invalid_product_data = {
         "id": 1,
@@ -46,7 +71,9 @@ async def test_create_product_with_invalid_data(client: AsyncClient):
         "discounted_price": 8000,
     }
 
-    response = await client.post("/products", json=invalid_product_data)
+    response = await client.post(
+        "/products", json=invalid_product_data, cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -54,23 +81,43 @@ async def test_create_product_with_invalid_data(client: AsyncClient):
 # 'GET /products/{product_id}' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_get_product_by_id_successfully(client: AsyncClient, mocker):
-    seller = Seller(id=1, corporate_name="판매자")
-    category = TertiaryCategory(id=1, name="카테고리")
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1, email="test@example.com", password="hashed_pw", user_type=UserType.SELLER
+    )
+    mock_seller = Seller(
+        id=1,
+        user_id=1,
+        registration_number="111-11-11111",
+        brand_name="TestBrand",
+        contact_number="000-000-0000",
+        user=mock_user,
+    )
+    mock_category = TertiaryCategory(id=1, name="카테고리")
 
     product = Product(
         id=1,
-        seller_id=1,
+        seller_id=mock_seller.id,
         product_name="테스트 상품",
-        category_id=1,
+        category_id=mock_category.id,
         price=100,
         inventory_quantity=10,
-        seller=seller,
-        category=category,
+        seller=mock_seller,
+        category=mock_category,
     )
 
+    mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": 1, "user_type": UserType.SELLER},
+    )
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=product)
 
-    response = await client.get(f"/products/{product.id}")
+    response = await client.get(
+        f"/products/{product.id}", cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -95,11 +142,16 @@ async def test_get_product_by_id_successfully(client: AsyncClient, mocker):
 # 'GET /products/{product_id}' API가 존재하지 않는 ID에 대해서는 404를 응답한다.
 @pytest.mark.asyncio
 async def test_get_product_by_id_not_found(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+
     non_existent_product_id = 0  # 존재하지 않는 ID
 
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=None)
 
-    response = await client.get(f"/products/{non_existent_product_id}")
+    response = await client.get(
+        f"/products/{non_existent_product_id}", cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -107,18 +159,29 @@ async def test_get_product_by_id_not_found(client: AsyncClient, mocker):
 # 'PATCH /products/{product_id}' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_update_product_successfully(client: AsyncClient, mocker):
-    seller = Seller(id=1, corporate_name="판매자")
-    category = TertiaryCategory(id=1, name="카테고리")
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1, email="test@example.com", password="hashed_pw", user_type=UserType.SELLER
+    )
+    mock_seller = Seller(
+        id=1,
+        user_id=1,
+        registration_number="111-11-11111",
+        brand_name="TestBrand",
+        contact_number="000-000-0000",
+        user=mock_user,
+    )
+    mock_category = TertiaryCategory(id=1, name="카테고리")
 
     product = Product(
         id=1,
-        seller_id=1,
+        seller_id=mock_seller.id,
         product_name="기존 상품",
-        category_id=1,
+        category_id=mock_category.id,
         price=100,
         inventory_quantity=10,
-        seller=seller,
-        category=category,
+        seller=mock_seller,
+        category=mock_category,
     )
 
     update_data = {"product_name": "업데이트된 상품", "price": 50}
@@ -133,12 +196,23 @@ async def test_update_product_successfully(client: AsyncClient, mocker):
         category=product.category,
     )
 
+    mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": 1, "user_type": UserType.SELLER},
+    )
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=product)
     mocker.patch.object(
         ProductRepository, "update_product", return_value=update_product
     )
 
-    response = await client.patch(f"/products/{product.id}", json=update_data)
+    response = await client.patch(
+        f"/products/{product.id}",
+        json=update_data,
+        cookies={"session_id": mock_session_id},
+    )
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -154,6 +228,9 @@ async def test_update_product_successfully(client: AsyncClient, mocker):
 # 'PATCH /products/{product_id}' API가 존재하지 않는 ID에 대해서는 404를 응답한다.
 @pytest.mark.asyncio
 async def test_update_product_not_found(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+
     non_existent_product_id = 0  # 존재하지 않는 ID
 
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=None)
@@ -161,7 +238,9 @@ async def test_update_product_not_found(client: AsyncClient, mocker):
     update_data = {"price": 50}
 
     response = await client.patch(
-        f"/products/{non_existent_product_id}", json=update_data
+        f"/products/{non_existent_product_id}",
+        json=update_data,
+        cookies={"session_id": mock_session_id},
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -170,24 +249,44 @@ async def test_update_product_not_found(client: AsyncClient, mocker):
 # 'DELETE /products/{product_id}' API가 성공적으로 동작한다.
 @pytest.mark.asyncio
 async def test_delete_product_successfully(client: AsyncClient, mocker):
-    seller = Seller(id=1, corporate_name="판매자")
-    category = TertiaryCategory(id=1, name="카테고리")
+    mock_session_id = "valid_session_id"
+    mock_user = User(
+        id=1, email="test@example.com", password="hashed_pw", user_type=UserType.SELLER
+    )
+    mock_seller = Seller(
+        id=1,
+        user_id=1,
+        registration_number="111-11-11111",
+        brand_name="TestBrand",
+        contact_number="000-000-0000",
+        user=mock_user,
+    )
+    mock_category = TertiaryCategory(id=1, name="카테고리")
 
     product = Product(
         id=1,
-        seller_id=1,
+        seller_id=mock_seller.id,
         product_name="기존 상품",
-        category_id=1,
+        category_id=mock_category.id,
         price=100,
         use_status=True,  # 해당 상품 사용 가능 상태
-        seller=seller,
-        category=category,
+        seller=mock_seller,
+        category=mock_category,
     )
 
+    mocker.patch.object(
+        SessionService,
+        "get_session",
+        return_value={"user_id": 1, "user_type": UserType.SELLER},
+    )
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+    mocker.patch.object(UserRepository, "get_user_by_id", return_value=mock_user)
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=product)
     mocker.patch.object(ProductRepository, "delete_product")
 
-    response = await client.delete(f"/products/{product.id}")
+    response = await client.delete(
+        f"/products/{product.id}", cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -195,10 +294,15 @@ async def test_delete_product_successfully(client: AsyncClient, mocker):
 # 'DELETE /products/{product_id}' API가 존재하지 않는 ID에 대해서는 404를 응답한다.
 @pytest.mark.asyncio
 async def test_delete_product_not_found(client: AsyncClient, mocker):
+    mock_session_id = "valid_session_id"
+    mocker.patch("src.service.auth.verify_seller", return_value=1)
+
     non_existent_product_id = 0  # 존재하지 않는 ID
 
     mocker.patch.object(ProductRepository, "get_product_by_id", return_value=None)
 
-    response = await client.delete(f"/products/{non_existent_product_id}")
+    response = await client.delete(
+        f"/products/{non_existent_product_id}", cookies={"session_id": mock_session_id}
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
### 작업 내용
- [x] `/products`로 시작하는 경로 접근 시 사용자 유형이 판매자(Seller)인지 확인하는 로직 추가
- [x] `/products/{product_id}`의 상품 수정, 상품 삭제, 특정 상품 조회는 상품 소유자(판매자)인지 확인하는 로직 추가
- [x] 위의 변경사항에 따른 테스트 코드 수정 및 추가 

### 설명
- 판매자가 아닌 사용자가 상품을 등록, 수정, 삭제, 조회와 같은 작업을 시도하는 것을 방지하기 위해 요청 시 사용자의 유형이 판매자(Seller)인지 확인하는 로직을 추가했습니다.
- 특정 상품을 수정하거나 삭제할 때, 해당 상품이 현재 로그인한 판매자에게 속한 것인지 확인하도록 추가했습니다. 세션 ID를 통해 사용자 정보를 확인하고, 상품의 소유자가 맞는 경우에만 작업을 수행할 수 있도록 했습니다.
- 위의 절차를 통해, 다른 사용자가 상품 정보를 임의로 변경하거나 삭제할 수 없도록 하였습니다.

### 테스트 코드
사용자 유형 확인 및 상품 소유 여부 검증 로직 추가에 따라 기존 테스트 코드를 수정하였습니다.
- `test_create_product_successfully` : 판매자가 올바른 세션 ID를 사용하여 상품을 성공적으로 생성하는지 테스트 
- `test_create_product_with_invalid_data` : 잘못된 데이터를 가진 요청에 대해 422 Unprocessable Entity 응답을 반환하는지, 세션 ID 확인을 포함하여 테스트
- `test_get_product_by_id_successfully` : 판매자가 본인 소유의 특정 상품을 조회하는지 테스트
- `test_get_product_by_id_not_found` : 존재하지 않는 상품을 조회하려 할 때 404 Not Found 응답을 반환하는지, 세션 ID 확인을 포함하여 테스트
- `test_update_product_successfully` : 판매자가 본인 소유의 상품을 업데이트하는지 테스트
- `test_update_product_not_found` : 존재하지 않는 상품을 업데이트하려고 할 때 404 Not Found 응답을 반환하는지, 세션 ID 확인
을 포함하여 테스트
- `test_delete_product_successfully` : 판매자가 본인 소유의 상품을 삭제하는지 테스트
- `test_delete_product_not_found` : 존재하지 않는 상품을 삭제하려고 할 때 404 Not Found 응답을 반환하는지, 세션 ID 확인을 포함하여 테스트
