### PR TITLE
상품 검색 API 구현

### DIFF
--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -21,6 +21,14 @@ store_router.add_api_route(
 )
 
 store_router.add_api_route(
+    methods=["GET"],
+    path="/search",
+    endpoint=goods.search_goods_handler,
+    response_model=list[goods.GetGoodsResponse],
+    status_code=status.HTTP_200_OK,
+)
+
+store_router.add_api_route(
     methods=["POST"],
     path="/products",
     endpoint=product.create_product_handler,

--- a/src/apis/store/goods.py
+++ b/src/apis/store/goods.py
@@ -1,12 +1,10 @@
 import re
 from typing import List
 
-from elasticsearch import AsyncElasticsearch
 from fastapi import Depends, HTTPException, Query
 
-from src.elastic_client import get_elasticsearch_client
 from src.models.product import Product
-from src.models.repository import ProductRepository
+from src.models.repository import ElasticsearchRepository, ProductRepository
 from src.schema.response import GetGoodsDetailResponse, GetGoodsResponse
 
 
@@ -72,34 +70,19 @@ async def get_goods_by_id_handler(
 
 
 async def search_goods_handler(
-    keyword: str, es_client: AsyncElasticsearch = Depends(get_elasticsearch_client)
+    keyword: str, es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository)
 ) -> List[GetGoodsResponse]:
-    try:
-        response = await es_client.search(
-            index="products",
-            body={
-                "query": {
-                    "multi_match": {
-                        "query": keyword,
-                        "fields": ["product_name", "brand_name", "ingredient"],
-                        "fuzziness": "AUTO",
-                    }
-                }
-            },
+    products = await es_repo.search_products(keyword)
+
+    response = [
+        GetGoodsResponse(
+            id=product["id"],
+            brand_name=product["brand_name"],
+            product_name=product["product_name"],
+            price=product["price"],
+            discounted_price=product["discounted_price"],
         )
+        for product in products
+    ]
 
-        products = [
-            GetGoodsResponse(
-                id=hit["_source"]["id"],
-                brand_name=hit["_source"]["brand_name"],
-                product_name=hit["_source"]["product_name"],
-                price=hit["_source"]["price"],
-                discounted_price=hit["_source"]["discounted_price"],
-            )
-            for hit in response["hits"]["hits"]
-        ]
-
-        return products
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return response

--- a/src/apis/store/goods.py
+++ b/src/apis/store/goods.py
@@ -72,6 +72,11 @@ async def get_goods_by_id_handler(
 async def search_goods_handler(
     keyword: str, es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository)
 ) -> List[GetGoodsResponse]:
+    if not keyword:
+        raise HTTPException(
+            status_code=422, detail="Keyword is required and cannot be empty."
+        )
+
     products = await es_repo.search_products(keyword)
 
     response = [

--- a/src/apis/store/product.py
+++ b/src/apis/store/product.py
@@ -32,6 +32,7 @@ async def create_product_handler(
     created_product: Product = await product_repo.create_product(product)
 
     product_info = created_product.model_dump()
+    product_info["brand_name"] = created_product.seller.brand_name
     await asyncio.create_task(add_product_to_stream(product_info=product_info))
 
     return GetProductResponse(

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -86,7 +86,9 @@ class ProductRepository:
 
     async def fetch_all_products(self) -> List[Product]:
         async with self.session as session:
-            result = await session.exec(select(Product))
+            result = await session.exec(
+                select(Product).options(selectinload(Product.seller))
+            )
             return list(result.all())
 
 

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -1,11 +1,13 @@
 from typing import List, Optional, TypeVar
 
+from elasticsearch import AsyncElasticsearch
 from fastapi import Depends
 from sqlalchemy.orm import joinedload, selectinload
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.apis.dependencies import get_session
+from src.elastic_client import get_elasticsearch_client
 from src.models.product import (
     PrimaryCategory,
     Product,
@@ -120,3 +122,37 @@ class UserRepository:
             )
         )
         return result.first() is None
+
+
+class ElasticsearchRepository:
+    def __init__(self, es: AsyncElasticsearch = Depends(get_elasticsearch_client)):
+        self.es = es
+
+    async def search_products(self, keyword: str) -> List[dict]:
+        response = await self.es.search(
+            index="products",
+            body={
+                "query": {
+                    "bool": {
+                        "should": [
+                            {
+                                "multi_match": {
+                                    "query": keyword,
+                                    "fields": [
+                                        "product_name",
+                                        "brand_name",
+                                        "ingredient",
+                                    ],
+                                    "fuzziness": "AUTO",
+                                }
+                            },
+                            {"match_phrase_prefix": {"product_name": keyword}},
+                            {"match_phrase_prefix": {"brand_name": keyword}},
+                            {"match_phrase_prefix": {"ingredient": keyword}},
+                        ]
+                    }
+                },
+                "sort": [{"id": {"order": "desc"}}],
+            },
+        )
+        return [hit["_source"] for hit in response["hits"]["hits"]]

--- a/src/service/sync.py
+++ b/src/service/sync.py
@@ -15,6 +15,7 @@ async def sync_all_products():
 
             for product in products:
                 product_info = product.model_dump()
+                product_info["brand_name"] = product.seller.brand_name
                 await es.index(
                     index="products",
                     id=product_info["id"],


### PR DESCRIPTION
### 작업 내용
- [x] 상품 검색 API - Elasticsearch를 활용한 상품 검색 기능 추가
- [x] 검색 키워드 없을 경우 422 에러 반환하는 로직 추가
- [x] 구현된 내용에 대한 테스트 코드 작성

### 설명
- Elasticsearch를 사용하여 `product_name`, `brand_name`, `ingredient`를 대상으로 키워드를 검색할 수 있는 기능을 구현했습니다.
- `multi_match`와 `match_phase_prefix` 쿼리를 사용하여 유연한 검색이 가능하도록 했고, 검색 결과는 상품 id를 기준으로 최신순으로 정렬되도록 설정하였습니다.
- 검색 시 필수 파라미터인 키워드가 주어지지 않으면 422 상태 코드를 반환하도록 처리했습니다.

### 테스트 코드
상품 검색 API (`GET /search`)에 대해 단위 테스트 진행
- 키워드를 포함한 검색 : 성공 - 200 OK 및 검색된 상품 리스트 반환
- 검색 결과가 없는 경우 : 성공 - 200 OK 및 빈 리스트(`[]`) 반환
- 잘못된 쿼리 파라미터 : 실패 - 422 Unprocessable Entity 반환

### 기타 사항
- 상품 정보가 많아지면 페이지네이션 추가 필요
