### PR TITLE
장바구니 API 구현

### DIFF
--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, status
 
-from src.apis.store import goods, product
+from src.apis.store import cart, goods, product
 
 store_router = APIRouter(tags=["store"])
 
@@ -57,4 +57,11 @@ store_router.add_api_route(
     path="/products/{product_id}",
     endpoint=product.delete_product_handler,
     status_code=status.HTTP_204_NO_CONTENT,
+)
+
+store_router.add_api_route(
+    methods=["POST"],
+    path="/cart",
+    endpoint=cart.add_to_cart_handler,
+    status_code=status.HTTP_201_CREATED,
 )

--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -76,6 +76,13 @@ store_router.add_api_route(
 
 store_router.add_api_route(
     methods=["DELETE"],
+    path="/cart",
+    endpoint=cart.clear_cart_handler,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+
+store_router.add_api_route(
+    methods=["DELETE"],
     path="/cart/{product_id}",
     endpoint=cart.delete_from_cart_handler,
     status_code=status.HTTP_204_NO_CONTENT,

--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, status
 
 from src.apis.store import cart, goods, product
+from src.schema import response
 
 store_router = APIRouter(tags=["store"])
 
@@ -70,7 +71,7 @@ store_router.add_api_route(
     methods=["GET"],
     path="/cart",
     endpoint=cart.get_cart_handler,
-    response_model=list[cart.CartResponse],
+    response_model=list[response.CartResponse],
     status_code=status.HTTP_200_OK,
 )
 
@@ -86,4 +87,11 @@ store_router.add_api_route(
     path="/cart/{product_id}",
     endpoint=cart.delete_from_cart_handler,
     status_code=status.HTTP_204_NO_CONTENT,
+)
+
+store_router.add_api_route(
+    methods=["PUT"],
+    path="/cart/{product_id}",
+    endpoint=cart.update_cart_quantity_handler,
+    status_code=status.HTTP_200_OK,
 )

--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -65,3 +65,11 @@ store_router.add_api_route(
     endpoint=cart.add_to_cart_handler,
     status_code=status.HTTP_201_CREATED,
 )
+
+store_router.add_api_route(
+    methods=["GET"],
+    path="/cart",
+    endpoint=cart.get_cart_handler,
+    response_model=list[cart.CartResponse],
+    status_code=status.HTTP_200_OK,
+)

--- a/src/apis/store/__init__.py
+++ b/src/apis/store/__init__.py
@@ -73,3 +73,10 @@ store_router.add_api_route(
     response_model=list[cart.CartResponse],
     status_code=status.HTTP_200_OK,
 )
+
+store_router.add_api_route(
+    methods=["DELETE"],
+    path="/cart/{product_id}",
+    endpoint=cart.delete_from_cart_handler,
+    status_code=status.HTTP_204_NO_CONTENT,
+)

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -30,6 +30,8 @@ async def add_to_cart_handler(
         quantity=request.quantity,
     )
 
+    await session_service.extend_session(session_id=session_id)
+
     response = JSONResponse(content={"message": "Goods added to cart successfully"})
     return response
 

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -81,3 +81,21 @@ async def delete_from_cart_handler(
     await cart_repo.delete_from_cart(
         user_id=session_data["user_id"], product_id=product_id
     )
+
+
+async def clear_cart_handler(
+    cart_repo: CartRepository = Depends(CartRepository),
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+):
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    if "user_id" not in session_data:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    await cart_repo.clear_cart(user_id=session_data["user_id"])

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -1,18 +1,17 @@
 from fastapi import Cookie, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
-from src.models.repository import CartRepository, ElasticsearchRepository
 from src.schema.request import AddToCartRequest
-from src.schema.response import CartResponse
 from src.service.auth import get_session_data
+from src.service.cart import CartService
 from src.service.session import SessionService
 
 
 async def add_to_cart_handler(
     request: AddToCartRequest,
-    cart_repo: CartRepository = Depends(CartRepository),
     session_id: str = Cookie(None),
     session_service: SessionService = Depends(),
+    cart_service: CartService = Depends(CartService),
 ):
     if not session_id:
         raise HTTPException(status_code=400, detail="Missing Session ID")
@@ -24,7 +23,7 @@ async def add_to_cart_handler(
     if "user_id" not in session_data:
         raise HTTPException(status_code=401, detail="User not authenticated")
 
-    await cart_repo.add_product(
+    await cart_service.add_to_cart(
         user_id=session_data["user_id"],
         product_id=request.product_id,
         quantity=request.quantity,
@@ -37,10 +36,9 @@ async def add_to_cart_handler(
 
 
 async def get_cart_handler(
-    cart_repo: CartRepository = Depends(CartRepository),
-    es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository),
     session_id: str = Cookie(None),
     session_service: SessionService = Depends(),
+    cart_service: CartService = Depends(CartService),
 ):
     if not session_id:
         raise HTTPException(status_code=400, detail="Missing Session ID")
@@ -52,23 +50,14 @@ async def get_cart_handler(
     if "user_id" not in session_data:
         raise HTTPException(status_code=401, detail="User not authenticated")
 
-    cart_data = await cart_repo.get_cart(user_id=session_data["user_id"])
-
-    cart_response = []
-    for product_id, quantity in cart_data.items():
-        product_info = await es_repo.get_product_by_id(product_id=product_id)
-        cart_response.append(
-            CartResponse(product_id=product_id, quantity=quantity, **product_info)
-        )
-
-    return cart_response
+    return await cart_service.get_cart(user_id=session_data["user_id"])
 
 
 async def delete_from_cart_handler(
     product_id: int,
-    cart_repo: CartRepository = Depends(CartRepository),
     session_id: str = Cookie(None),
     session_service: SessionService = Depends(),
+    cart_service: CartService = Depends(CartService),
 ):
     if not session_id:
         raise HTTPException(status_code=400, detail="Missing Session ID")
@@ -80,15 +69,15 @@ async def delete_from_cart_handler(
     if "user_id" not in session_data:
         raise HTTPException(status_code=401, detail="User not authenticated")
 
-    await cart_repo.delete_from_cart(
+    await cart_service.delete_from_cart(
         user_id=session_data["user_id"], product_id=product_id
     )
 
 
 async def clear_cart_handler(
-    cart_repo: CartRepository = Depends(CartRepository),
     session_id: str = Cookie(None),
     session_service: SessionService = Depends(),
+    cart_service: CartService = Depends(CartService),
 ):
     if not session_id:
         raise HTTPException(status_code=400, detail="Missing Session ID")
@@ -100,4 +89,4 @@ async def clear_cart_handler(
     if "user_id" not in session_data:
         raise HTTPException(status_code=401, detail="User not authenticated")
 
-    await cart_repo.clear_cart(user_id=session_data["user_id"])
+    await cart_service.clear_cart(user_id=session_data["user_id"])

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -1,8 +1,9 @@
 from fastapi import Cookie, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
-from src.models.repository import CartRepository
+from src.models.repository import CartRepository, ElasticsearchRepository
 from src.schema.request import AddToCartRequest
+from src.schema.response import CartResponse
 from src.service.auth import get_session_data
 from src.service.session import SessionService
 
@@ -31,3 +32,31 @@ async def add_to_cart_handler(
 
     response = JSONResponse(content={"message": "Goods added to cart successfully"})
     return response
+
+
+async def get_cart_handler(
+    cart_repo: CartRepository = Depends(CartRepository),
+    es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository),
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+):
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    if "user_id" not in session_data:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    cart_data = await cart_repo.get_cart(user_id=session_data["user_id"])
+
+    cart_response = []
+    for product_id, quantity in cart_data.items():
+        product_info = await es_repo.get_product_by_id(product_id=product_id)
+        cart_response.append(
+            CartResponse(product_id=product_id, quantity=quantity, **product_info)
+        )
+
+    return cart_response

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -60,3 +60,24 @@ async def get_cart_handler(
         )
 
     return cart_response
+
+
+async def delete_from_cart_handler(
+    product_id: int,
+    cart_repo: CartRepository = Depends(CartRepository),
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+):
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    if "user_id" not in session_data:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    await cart_repo.delete_from_cart(
+        user_id=session_data["user_id"], product_id=product_id
+    )

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -23,16 +23,18 @@ async def add_to_cart_handler(
     if "user_id" not in session_data:
         raise HTTPException(status_code=401, detail="User not authenticated")
 
-    await cart_service.add_to_cart(
+    result = await cart_service.add_to_cart(
         user_id=session_data["user_id"],
         product_id=request.product_id,
         quantity=request.quantity,
     )
 
+    if not result["is_success"]:
+        raise HTTPException(status_code=result["status_code"], detail=result["message"])
+
     await session_service.extend_session(session_id=session_id)
 
-    response = JSONResponse(content={"message": "Goods added to cart successfully"})
-    return response
+    return JSONResponse(content=result["message"])
 
 
 async def get_cart_handler(

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -1,0 +1,33 @@
+from fastapi import Cookie, Depends, HTTPException
+from fastapi.responses import JSONResponse
+
+from src.models.repository import CartRepository
+from src.schema.request import AddToCartRequest
+from src.service.auth import get_session_data
+from src.service.session import SessionService
+
+
+async def add_to_cart_handler(
+    request: AddToCartRequest,
+    cart_repo: CartRepository = Depends(CartRepository),
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+):
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    if "user_id" not in session_data:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    await cart_repo.add_product(
+        user_id=session_data["user_id"],
+        product_id=request.product_id,
+        quantity=request.quantity,
+    )
+
+    response = JSONResponse(content={"message": "Goods added to cart successfully"})
+    return response

--- a/src/apis/store/cart.py
+++ b/src/apis/store/cart.py
@@ -1,7 +1,7 @@
 from fastapi import Cookie, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
-from src.schema.request import AddToCartRequest
+from src.schema.request import AddToCartRequest, UpdateCartRequest
 from src.service.auth import get_session_data
 from src.service.cart import CartService
 from src.service.session import SessionService
@@ -92,3 +92,32 @@ async def clear_cart_handler(
         raise HTTPException(status_code=401, detail="User not authenticated")
 
     await cart_service.clear_cart(user_id=session_data["user_id"])
+
+
+async def update_cart_quantity_handler(
+    request: UpdateCartRequest,
+    product_id: int,
+    session_id: str = Cookie(None),
+    session_service: SessionService = Depends(),
+    cart_service: CartService = Depends(CartService),
+):
+    if not session_id:
+        raise HTTPException(status_code=400, detail="Missing Session ID")
+
+    session_data = await get_session_data(
+        session_id=session_id, session_service=session_service
+    )
+
+    if "user_id" not in session_data:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    result = await cart_service.update_cart_quantity(
+        user_id=session_data["user_id"],
+        product_id=product_id,
+        quantity=request.quantity,
+    )
+
+    if not result["is_success"]:
+        raise HTTPException(status_code=result["status_code"], detail=result["message"])
+
+    return JSONResponse(content={"message": result["message"]})

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -257,3 +257,8 @@ class CartRepository:
     async def clear_cart(self, user_id: str):
         cart_key = self.generate_cart_key(user_id=user_id)
         await self.redis.delete(cart_key)
+
+    async def get_product_quantity_in_cart(self, user_id: int, product_id: int) -> int:
+        cart_key = self.generate_cart_key(user_id=user_id)
+        quantity = await self.redis.hget(cart_key, product_id)
+        return int(quantity) if quantity else 0

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -238,3 +238,7 @@ class CartRepository:
     async def get_cart(self, user_id: str) -> dict:
         cart_key = f"cart:{user_id}"
         return await self.redis.hgetall(cart_key)
+
+    async def delete_from_cart(self, user_id: str, product_id: int):
+        cart_key = f"cart:{user_id}"
+        await self.redis.hdel(cart_key, product_id)

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -113,6 +113,14 @@ class ProductRepository:
         )
         return result.one_or_none()
 
+    async def get_product_stock(self, product_id: int) -> Optional[int]:
+        result = await self.session.exec(
+            select(Product.inventory_quantity).where(
+                Product.id == product_id, Product.use_status == True
+            )
+        )
+        return result.one_or_none()
+
 
 class UserRepository:
     def __init__(self, session: AsyncSession = Depends(get_session)):

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -239,18 +239,21 @@ class CartRepository:
     def __init__(self, redis: Redis = Depends(get_redis_client)):
         self.redis = redis
 
+    def generate_cart_key(self, user_id: int) -> str:
+        return f"cart:{user_id}"
+
     async def add_product(self, user_id: int, product_id: int, quantity: int):
-        cart_key = f"cart:{user_id}"
+        cart_key = self.generate_cart_key(user_id=user_id)
         await self.redis.hset(cart_key, product_id, quantity)
 
     async def get_cart(self, user_id: str) -> dict:
-        cart_key = f"cart:{user_id}"
+        cart_key = self.generate_cart_key(user_id=user_id)
         return await self.redis.hgetall(cart_key)
 
     async def delete_from_cart(self, user_id: str, product_id: int):
-        cart_key = f"cart:{user_id}"
+        cart_key = self.generate_cart_key(user_id=user_id)
         await self.redis.hdel(cart_key, product_id)
 
     async def clear_cart(self, user_id: str):
-        cart_key = f"cart:{user_id}"
+        cart_key = self.generate_cart_key(user_id=user_id)
         await self.redis.delete(cart_key)

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -234,3 +234,7 @@ class CartRepository:
     async def add_product(self, user_id: int, product_id: int, quantity: int):
         cart_key = f"cart:{user_id}"
         await self.redis.hset(cart_key, product_id, quantity)
+
+    async def get_cart(self, user_id: str) -> dict:
+        cart_key = f"cart:{user_id}"
+        return await self.redis.hgetall(cart_key)

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -242,3 +242,7 @@ class CartRepository:
     async def delete_from_cart(self, user_id: str, product_id: int):
         cart_key = f"cart:{user_id}"
         await self.redis.hdel(cart_key, product_id)
+
+    async def clear_cart(self, user_id: str):
+        cart_key = f"cart:{user_id}"
+        await self.redis.delete(cart_key)

--- a/src/schema/request.py
+++ b/src/schema/request.py
@@ -55,3 +55,8 @@ class RegisterUserRequest(BaseModel):
 class LoginUserRequest(BaseModel):
     email: EmailStr
     password: str
+
+
+class AddToCartRequest(BaseModel):
+    product_id: int
+    quantity: int

--- a/src/schema/request.py
+++ b/src/schema/request.py
@@ -60,3 +60,7 @@ class LoginUserRequest(BaseModel):
 class AddToCartRequest(BaseModel):
     product_id: int
     quantity: int
+
+
+class UpdateCartRequest(BaseModel):
+    quantity: int

--- a/src/schema/response.py
+++ b/src/schema/response.py
@@ -68,3 +68,11 @@ class GetBuyerInfoResponse(BaseModel):
     name: str
     phone_number: str
     address: str
+
+
+class CartResponse(BaseModel):
+    product_id: int
+    product_name: str
+    price: int
+    discounted_price: int
+    quantity: int

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -76,4 +76,14 @@ class CartService:
         )
 
     async def clear_cart(self, user_id: int):
+        cart_data = await self.cart_repo.get_cart(user_id=user_id)
+        for product_id, quantity in cart_data.items():
+            reservation_key = self.inventory_service.generate_reservation_key(
+                product_id=product_id
+            )
+            if await self.inventory_service.redis.exists(reservation_key):
+                await self.inventory_service.release_product(
+                    user_id=user_id, product_id=product_id
+                )
+
         await self.cart_repo.clear_cart(user_id=user_id)

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -71,6 +71,9 @@ class CartService:
 
     async def delete_from_cart(self, user_id: int, product_id: int):
         await self.cart_repo.delete_from_cart(user_id=user_id, product_id=product_id)
+        await self.inventory_service.release_product(
+            user_id=user_id, product_id=product_id
+        )
 
     async def clear_cart(self, user_id: int):
         await self.cart_repo.clear_cart(user_id=user_id)

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -1,0 +1,37 @@
+from fastapi import Depends
+
+from src.models.repository import CartRepository, ElasticsearchRepository
+from src.schema.response import CartResponse
+
+
+class CartService:
+    def __init__(
+        self,
+        cart_repo: CartRepository = Depends(CartRepository),
+        es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository),
+    ):
+        self.cart_repo = cart_repo
+        self.es_repo = es_repo
+
+    async def add_to_cart(self, user_id: int, product_id: int, quantity: int):
+        await self.cart_repo.add_product(
+            user_id=user_id, product_id=product_id, quantity=quantity
+        )
+
+    async def get_cart(self, user_id: int) -> list[CartResponse]:
+        cart_data = await self.cart_repo.get_cart(user_id=user_id)
+
+        cart_response = []
+        for product_id, quantity in cart_data.items():
+            product_info = await self.es_repo.get_product_by_id(product_id=product_id)
+            cart_response.append(
+                CartResponse(product_id=product_id, quantity=quantity, **product_info)
+            )
+
+        return cart_response
+
+    async def delete_from_cart(self, user_id: int, product_id: int):
+        await self.cart_repo.delete_from_cart(user_id=user_id, product_id=product_id)
+
+    async def clear_cart(self, user_id: int):
+        await self.cart_repo.clear_cart(user_id=user_id)

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -141,6 +141,10 @@ class CartService:
             await self.cart_repo.delete_from_cart(
                 user_id=user_id, product_id=product_id
             )
+            if await self.inventory_service.is_product_reserved(product_id=product_id):
+                await self.inventory_service.release_product(
+                    user_id=user_id, product_id=product_id
+                )
             return {"is_success": True, "message": "Product removed from cart"}
 
         current_quantity: int = await self.cart_repo.get_product_quantity_in_cart(

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -1,6 +1,10 @@
 from fastapi import Depends
 
-from src.models.repository import CartRepository, ElasticsearchRepository
+from src.models.repository import (
+    CartRepository,
+    ElasticsearchRepository,
+    ProductRepository,
+)
 from src.schema.response import CartResponse
 
 
@@ -9,14 +13,34 @@ class CartService:
         self,
         cart_repo: CartRepository = Depends(CartRepository),
         es_repo: ElasticsearchRepository = Depends(ElasticsearchRepository),
+        product_repo: ProductRepository = Depends(ProductRepository),
     ):
         self.cart_repo = cart_repo
         self.es_repo = es_repo
+        self.product_repo = product_repo
 
-    async def add_to_cart(self, user_id: int, product_id: int, quantity: int):
+    async def add_to_cart(self, user_id: int, product_id: int, quantity: int) -> dict:
+        # 1. MySQL에서 재고 확인
+        stock = await self.product_repo.get_product_stock(product_id=product_id)
+
+        if stock is None:
+            return {
+                "is_success": False,
+                "status_code": 404,
+                "message": "Product not found or unavailable",
+            }
+        if stock < quantity:
+            return {
+                "is_success": False,
+                "status_code": 400,
+                "message": "Insufficient stock",
+            }
+
+        # 2. 장바구니에 상품 추가 로직 호출
         await self.cart_repo.add_product(
             user_id=user_id, product_id=product_id, quantity=quantity
         )
+        return {"is_success": True, "message": "Goods added to cart successfully"}
 
     async def get_cart(self, user_id: int) -> list[CartResponse]:
         cart_data = await self.cart_repo.get_cart(user_id=user_id)

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -78,10 +78,7 @@ class CartService:
     async def clear_cart(self, user_id: int):
         cart_data = await self.cart_repo.get_cart(user_id=user_id)
         for product_id, quantity in cart_data.items():
-            reservation_key = self.inventory_service.generate_reservation_key(
-                product_id=product_id
-            )
-            if await self.inventory_service.redis.exists(reservation_key):
+            if await self.inventory_service.is_product_reserved(product_id=product_id):
                 await self.inventory_service.release_product(
                     user_id=user_id, product_id=product_id
                 )

--- a/src/service/cart.py
+++ b/src/service/cart.py
@@ -23,38 +23,87 @@ class CartService:
         self.inventory_service = inventory_service
 
     async def add_to_cart(self, user_id: int, product_id: int, quantity: int) -> dict:
-        # 1. MySQL에서 재고 확인
-        stock = await self.product_repo.get_product_stock(product_id=product_id)
-
-        if stock is None:
-            return {
-                "is_success": False,
-                "status_code": 404,
-                "message": "Product not found or unavailable",
-            }
-        if stock < quantity:
-            return {
-                "is_success": False,
-                "status_code": 400,
-                "message": "Insufficient stock",
-            }
-
-        # 2. 재고가 10개 이하일 때 Redis에서 예약 관리
-        if stock <= 10:
-            reservation_result = await self.inventory_service.reserve_product(
-                user_id=user_id, product_id=product_id, quantity=quantity, stock=stock
+        # 1. 예약 관리 여부 확인
+        if await self.inventory_service.is_product_reserved(product_id=product_id):
+            # 2. 예약 관리 중일 때 예약 슬롯 확인
+            empty_slots: list = (
+                await self.inventory_service.get_empty_reservation_slots(
+                    product_id=product_id
+                )
             )
-            if not reservation_result:
+            available_quantity: int = len(empty_slots)
+
+            if available_quantity == 0:
+                return {
+                    "is_success": False,
+                    "status_code": 400,
+                    "message": "Insufficient stock",
+                }
+            elif available_quantity < quantity:
+                return {
+                    "is_success": False,
+                    "status_code": 400,
+                    "message": "Quantity requested is more than available",
+                }
+        else:
+            # 3. 비예약 관리 상품인 경우 MySQL에서 재고 확인
+            stock: int | None = await self.product_repo.get_product_stock(
+                product_id=product_id
+            )
+
+            if stock is None:
+                return {
+                    "is_success": False,
+                    "status_code": 404,
+                    "message": "Product not found or unavailable",
+                }
+            elif stock < quantity:
+                return {
+                    "is_success": False,
+                    "status_code": 400,
+                    "message": "Insufficient stock",
+                }
+
+            # 4. 재고가 10개 이하일 때 Redis에서 예약 관리하도록 슬롯 생성
+            if stock <= 10:
+                is_created_slots: bool = (
+                    await self.inventory_service.create_reservation_slots(
+                        product_id=product_id, stock=stock
+                    )
+                )
+                if not is_created_slots:
+                    return {
+                        "is_success": False,
+                        "status_code": 503,
+                        "message": "Service temporarily unavailable. Please try again later.",
+                    }
+
+        # 5. 장바구니에 상품 추가 또는 수량 업데이트
+        current_quantity: int = await self.cart_repo.get_product_quantity_in_cart(
+            user_id=user_id, product_id=product_id
+        )
+        if current_quantity:
+            total_quantity = current_quantity + quantity
+            await self.cart_repo.add_product(
+                user_id=user_id, product_id=product_id, quantity=total_quantity
+            )
+        else:
+            await self.cart_repo.add_product(
+                user_id=user_id, product_id=product_id, quantity=quantity
+            )
+
+        # 6. 예약 관리 중인 상품일 때 예약 슬롯 업데이트
+        if await self.inventory_service.is_product_reserved(product_id=product_id):
+            is_reservation_result = await self.inventory_service.reserve_product(
+                user_id=user_id, product_id=product_id, quantity=quantity
+            )
+            if not is_reservation_result:
                 return {
                     "is_success": False,
                     "status_code": 503,
-                    "message": "Service temporarily unavailable. Please try again later.",
+                    "message": "Reservation failed. Please try again later.",
                 }
 
-        # 3. 장바구니에 상품 추가 로직 호출
-        await self.cart_repo.add_product(
-            user_id=user_id, product_id=product_id, quantity=quantity
-        )
         return {"is_success": True, "message": "Goods added to cart successfully"}
 
     async def get_cart(self, user_id: int) -> list[CartResponse]:

--- a/src/service/inventory.py
+++ b/src/service/inventory.py
@@ -1,0 +1,46 @@
+from fastapi import Depends
+from redis.asyncio import Redis
+
+from src.redis_client import get_redis_client
+
+
+class InventoryService:
+    def __init__(self, redis: Redis = Depends(get_redis_client)):
+        self.redis = redis
+
+    def generate_reservation_key(self, product_id: int) -> str:
+        return f"product:{product_id}:inventory"
+
+    async def create_reservation_slots(self, product_id: int, stock: int):
+        reservation_key = self.generate_reservation_key(product_id=product_id)
+
+        try:
+            for i in range(1, stock + 1):
+                await self.redis.hset(
+                    reservation_key, mapping={str(i): "" for i in range(1, stock + 1)}
+                )
+            return True
+        except Exception as e:
+            print(f"Redis error occurred: {e}")
+            return False
+
+    async def reserve_product(
+        self, user_id: int, product_id: int, quantity: int, stock: int
+    ) -> bool:
+        reservation_key = self.generate_reservation_key(product_id=product_id)
+
+        if not await self.redis.exists(reservation_key):
+            if not await self.create_reservation_slots(
+                product_id=product_id, stock=stock
+            ):
+                return False
+
+        reserved_items = []
+        for i in range(1, quantity + 1):
+            item_key = await self.redis.hget(reservation_key, str(i))
+            if item_key == "":  # 예약 가능
+                await self.redis.hset(reservation_key, str(i), user_id)
+                reserved_items.append(i)
+            else:
+                return False
+        return True

--- a/src/service/inventory.py
+++ b/src/service/inventory.py
@@ -44,3 +44,15 @@ class InventoryService:
             else:
                 return False
         return True
+
+    async def release_product(self, user_id: int, product_id: int):
+        reservation_key = self.generate_reservation_key(product_id=product_id)
+
+        if await self.redis.exists(reservation_key):
+            all_slots = await self.redis.hgetall(reservation_key)
+            user_slots = [
+                slot for slot, value in all_slots.items() if value == str(user_id)
+            ]
+
+            for slot_number in user_slots:
+                await self.redis.hset(reservation_key, slot_number, "")

--- a/src/service/session.py
+++ b/src/service/session.py
@@ -29,3 +29,6 @@ class SessionService:
 
     async def delete_session(self, session_id: str):
         await self.redis_client.delete(session_id)
+
+    async def extend_session(self, session_id: str, ttl: int = 3600):
+        await self.redis_client.expire(session_id, ttl)


### PR DESCRIPTION
### 작업 내용
- [x] 장바구니 상품 추가 기능
- [x] 장바구니 상품 수량 업데이트 기능
- [x] 장바구니 상품 삭제 기능
- [x] 장바구니 비우기 기능
- [x] Redis를 이용한 장바구니 저장
- [x] Redis를 이용한 재고 예약 및 관리 기능 추가
- [x] MySQL의 실제 재고가 10개 이하일 때 Redis로 예약 관리 전환

### 설명
- 장바구니 상품 추가 및 수량 업데이트 : 사용자가 장바구니에 상품을 추가할 때 이미 장바구니에 해당 상품이 있는 경우 수량을 추가하도록 했으며, 재고 확인 후 처리했습니다. Redis에서 관리 중인 상품의 경우 예약 슬롯을 확인하고 수량에 따라 예약 관리하도록 했습니다.
- 장바구니 비우기 및 상품 삭제 : 장바구니 전체 비우기 기능과 특정 상품을 삭제하는 기능을 구현했습니다. 장바구니에서 삭제될 경우 예약 슬롯에서도 함꼐 해제되도록 처리했습니다.
- Redis를 이용한 장바구니 저장 : 장바구니 데이터를 Redis에 `'cart:{user_id}'` 키를 가진 해시 구조로 저장하여 관리하도록 했습니다.
- 재고 관리 : MySQL에서 실제 재고가 10개 이하일 때는 Redis를 통해 재고 관리를 하여 실제 재고보다 많은 구매가 이루어지지 않도록 관리했습니다.

### 기타 사항
- 장바구니 TTL 설정 및 TTL 완료 시 예약 슬롯 해제 로직 작성 필요
- 장바구니 기능을 이용 중인 사용자의 세션 ID TTL 갱신 처리 필요
- MySQL에서 상품의 재고가 증가될 경우 Redis에서 예약 관리 해제 필요
- 장바구니 기능 전반에 관한 테스트 코드 작성 필요